### PR TITLE
Fix LEFT JOIN

### DIFF
--- a/clickhouse-nfts/Makefile
+++ b/clickhouse-nfts/Makefile
@@ -23,5 +23,5 @@ dev:
 	substreams-sink-sql run clickhouse://default:default@localhost:9000/default substreams.yaml -e $(ENDPOINT) 22211598: --final-blocks-only --undo-buffer-size 1 --on-module-hash-mistmatch=warn --batch-block-flush-interval 1 --development-mode
 
 .PHONY: setup
-setup: build
+setup: pack
 	substreams-sink-sql setup clickhouse://default:default@localhost:9000/default substreams.yaml

--- a/clickhouse-nfts/schema.sql
+++ b/clickhouse-nfts/schema.sql
@@ -495,7 +495,7 @@ CREATE TABLE IF NOT EXISTS erc721_owners (
 ) ENGINE = ReplacingMergeTree(global_sequence)
 ORDER BY (contract, token_id);
 
-CREATE MATERIALIZED VIEW mv_erc721_owners
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_erc721_owners
 TO erc721_owners
 AS
 SELECT
@@ -564,7 +564,7 @@ CREATE TABLE IF NOT EXISTS seaport_sales (
 ENGINE = ReplacingMergeTree()
 ORDER BY (offer_token, offer_token_id, order_hash);
 
-CREATE MATERIALIZED VIEW mv_seaport_sales
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_seaport_sales
 TO seaport_sales
 AS
 SELECT
@@ -592,8 +592,8 @@ SELECT
     toUInt256(tupleElement(c,4)) AS consideration_amount,
     tupleElement(c,5)            AS consideration_recipient
 FROM seaport_order_fulfilled AS f
-ARRAY JOIN f.offer AS o
-ARRAY JOIN f.consideration AS c; -- independent explode → no size-mismatch
+LEFT ARRAY JOIN f.offer AS o
+LEFT ARRAY JOIN f.consideration AS c;
 
 
 -- Seaport Offers --
@@ -653,8 +653,7 @@ SELECT
     tupleElement(o, 3) AS token_id,
     tupleElement(o, 4) AS amount
 FROM seaport_order_fulfilled
-ARRAY JOIN offer AS o;   -- explode one row per tuple
-
+LEFT ARRAY JOIN offer AS o;
 
 -- Seaport Considerations --
 -- A consideration is what the offerer expects in return for their offer. It’s essentially the "payment" they expect to receive, which can also be:
@@ -715,6 +714,6 @@ SELECT
     tupleElement(c, 4) AS amount,
     tupleElement(c, 5) AS recipient
 FROM seaport_order_fulfilled
-ARRAY JOIN consideration AS c;
+LEFT ARRAY JOIN consideration AS c;
 
 

--- a/clickhouse-nfts/schema.views.erc721.sql
+++ b/clickhouse-nfts/schema.views.erc721.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS erc721_owners (
 ) ENGINE = ReplacingMergeTree(global_sequence)
 ORDER BY (contract, token_id);
 
-CREATE MATERIALIZED VIEW mv_erc721_owners
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_erc721_owners
 TO erc721_owners
 AS
 SELECT

--- a/clickhouse-nfts/schema.views.seaport.sales.sql
+++ b/clickhouse-nfts/schema.views.seaport.sales.sql
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS seaport_sales (
 ENGINE = ReplacingMergeTree()
 ORDER BY (offer_token, offer_token_id, order_hash);
 
-CREATE MATERIALIZED VIEW mv_seaport_sales
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_seaport_sales
 TO seaport_sales
 AS
 SELECT
@@ -77,5 +77,5 @@ SELECT
     toUInt256(tupleElement(c,4)) AS consideration_amount,
     tupleElement(c,5)            AS consideration_recipient
 FROM seaport_order_fulfilled AS f
-ARRAY JOIN f.offer AS o
-ARRAY JOIN f.consideration AS c; -- independent explode → no size-mismatch
+LEFT ARRAY JOIN f.offer AS o
+LEFT ARRAY JOIN f.consideration AS c;

--- a/clickhouse-nfts/schema.views.seaport.sql
+++ b/clickhouse-nfts/schema.views.seaport.sql
@@ -55,8 +55,7 @@ SELECT
     tupleElement(o, 3) AS token_id,
     tupleElement(o, 4) AS amount
 FROM seaport_order_fulfilled
-ARRAY JOIN offer AS o;   -- explode one row per tuple
-
+LEFT ARRAY JOIN offer AS o;
 
 -- Seaport Considerations --
 -- A consideration is what the offerer expects in return for their offer. It’s essentially the "payment" they expect to receive, which can also be:
@@ -117,4 +116,4 @@ SELECT
     tupleElement(c, 4) AS amount,
     tupleElement(c, 5) AS recipient
 FROM seaport_order_fulfilled
-ARRAY JOIN consideration AS c;
+LEFT ARRAY JOIN consideration AS c;

--- a/clickhouse-nfts/substreams.yaml
+++ b/clickhouse-nfts/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: evm_nft_tokens
-  version: v0.4.0
+  version: v0.4.1
   url: https://github.com/pinax-network/substreams-evm-tokens
   description: NFT tokens for EVM blockchains.
   image: ../image.png

--- a/clickhouse/schema.sql
+++ b/clickhouse/schema.sql
@@ -771,5 +771,3 @@ SELECT
    sum(1) AS transactions
 FROM swaps
 GROUP BY pool, timestamp;
-
-


### PR DESCRIPTION
## Error ❌ 

> setup: exec schema: parsing schema: line 595:0 <EOF> or ';' was expected, but got: "ARRAY"
ARRAY JOIN f.consideration AS c; -- independent explode → no size-mismatch

## Solution

Added `LEFT`

```sql
LEFT ARRAY JOIN consideration AS c;
```
https://clickhouse.com/docs/sql-reference/statements/select/array-join

![image](https://github.com/user-attachments/assets/9b606b41-756d-4089-89d9-6bf4aa6899e1)
