### PR TITLE
Add `tx.from` & `tx.to`

### DIFF
--- a/proto/src/pb/evm.uniswap.v2.rs
+++ b/proto/src/pb/evm.uniswap.v2.rs
@@ -78,16 +78,22 @@ pub struct Swap {
     /// -- transaction --
     #[prost(bytes="vec", tag="1")]
     pub tx_hash: ::prost::alloc::vec::Vec<u8>,
+    /// tx.from
+    #[prost(bytes="vec", tag="2")]
+    pub tx_from: ::prost::alloc::vec::Vec<u8>,
+    /// tx.to
+    #[prost(bytes="vec", tag="3")]
+    pub tx_to: ::prost::alloc::vec::Vec<u8>,
     /// -- call --
-    #[prost(bytes="vec", optional, tag="2")]
+    #[prost(bytes="vec", optional, tag="4")]
     pub caller: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     /// -- log --
     ///
     /// log.address
-    #[prost(bytes="vec", tag="3")]
+    #[prost(bytes="vec", tag="5")]
     pub contract: ::prost::alloc::vec::Vec<u8>,
     /// log.ordinal
-    #[prost(uint64, tag="4")]
+    #[prost(uint64, tag="6")]
     pub ordinal: u64,
     /// -- event --
     #[prost(bytes="vec", tag="10")]

--- a/proto/src/pb/evm.uniswap.v3.rs
+++ b/proto/src/pb/evm.uniswap.v3.rs
@@ -134,39 +134,45 @@ pub struct Swap {
     /// -- transaction --
     #[prost(bytes="vec", tag="1")]
     pub tx_hash: ::prost::alloc::vec::Vec<u8>,
+    /// tx.from
+    #[prost(bytes="vec", tag="2")]
+    pub tx_from: ::prost::alloc::vec::Vec<u8>,
+    /// tx.to
+    #[prost(bytes="vec", tag="3")]
+    pub tx_to: ::prost::alloc::vec::Vec<u8>,
     /// -- call --
-    #[prost(bytes="vec", optional, tag="2")]
+    #[prost(bytes="vec", optional, tag="4")]
     pub caller: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     /// -- log --
     ///
     /// log.address
-    #[prost(bytes="vec", tag="3")]
+    #[prost(bytes="vec", tag="5")]
     pub contract: ::prost::alloc::vec::Vec<u8>,
     /// log.ordinal
-    #[prost(uint64, tag="4")]
+    #[prost(uint64, tag="6")]
     pub ordinal: u64,
     /// -- event --
     ///
     /// address
-    #[prost(bytes="vec", tag="21")]
+    #[prost(bytes="vec", tag="10")]
     pub sender: ::prost::alloc::vec::Vec<u8>,
     /// address
-    #[prost(bytes="vec", tag="22")]
+    #[prost(bytes="vec", tag="11")]
     pub recipient: ::prost::alloc::vec::Vec<u8>,
     /// int256
-    #[prost(string, tag="23")]
+    #[prost(string, tag="12")]
     pub amount0: ::prost::alloc::string::String,
     /// int256
-    #[prost(string, tag="24")]
+    #[prost(string, tag="13")]
     pub amount1: ::prost::alloc::string::String,
     /// uint160
-    #[prost(string, tag="25")]
+    #[prost(string, tag="14")]
     pub sqrt_price_x96: ::prost::alloc::string::String,
     /// uint128
-    #[prost(string, tag="26")]
+    #[prost(string, tag="15")]
     pub liquidity: ::prost::alloc::string::String,
     /// int24
-    #[prost(int32, tag="27")]
+    #[prost(int32, tag="16")]
     pub tick: i32,
 }
 /// / @notice Emitted when the owner of the factory is changed

--- a/proto/src/pb/evm.uniswap.v4.rs
+++ b/proto/src/pb/evm.uniswap.v4.rs
@@ -88,16 +88,22 @@ pub struct Swap {
     /// -- transaction --
     #[prost(bytes="vec", tag="1")]
     pub tx_hash: ::prost::alloc::vec::Vec<u8>,
+    /// tx.from
+    #[prost(bytes="vec", tag="2")]
+    pub tx_from: ::prost::alloc::vec::Vec<u8>,
+    /// tx.to
+    #[prost(bytes="vec", tag="3")]
+    pub tx_to: ::prost::alloc::vec::Vec<u8>,
     /// -- call --
-    #[prost(bytes="vec", optional, tag="2")]
+    #[prost(bytes="vec", optional, tag="4")]
     pub caller: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     /// -- log --
     ///
     /// log.address
-    #[prost(bytes="vec", tag="3")]
+    #[prost(bytes="vec", tag="5")]
     pub contract: ::prost::alloc::vec::Vec<u8>,
     /// log.ordinal
-    #[prost(uint64, tag="4")]
+    #[prost(uint64, tag="6")]
     pub ordinal: u64,
     /// -- event --
     ///

--- a/proto/v1/uniswap-v2.proto
+++ b/proto/v1/uniswap-v2.proto
@@ -52,13 +52,15 @@ message Sync {
 message Swap {
   // -- transaction --
   bytes tx_hash = 1;
+  bytes tx_from = 2; // tx.from
+  bytes tx_to = 3; // tx.to
 
   // -- call --
-  optional bytes caller = 2;
+  optional bytes caller = 4;
 
   // -- log --
-  bytes contract = 3; // log.address
-  uint64 ordinal = 4; // log.ordinal
+  bytes contract = 5; // log.address
+  uint64 ordinal = 6; // log.ordinal
 
   // -- event --
   bytes sender = 10;

--- a/proto/v1/uniswap-v3.proto
+++ b/proto/v1/uniswap-v3.proto
@@ -101,22 +101,24 @@ message Initialize {
 message Swap {
   // -- transaction --
   bytes tx_hash = 1;
+  bytes tx_from = 2; // tx.from
+  bytes tx_to = 3; // tx.to
 
   // -- call --
-  optional bytes caller = 2;
+  optional bytes caller = 4;
 
   // -- log --
-  bytes contract = 3; // log.address
-  uint64 ordinal = 4; // log.ordinal
+  bytes contract = 5; // log.address
+  uint64 ordinal = 6; // log.ordinal
 
   // -- event --
-  bytes sender = 21; // address
-  bytes recipient = 22; // address
-  string amount0 = 23; // int256
-  string amount1 = 24; // int256
-  string sqrt_price_x96 = 25; // uint160
-  string liquidity = 26; // uint128
-  int32 tick = 27; // int24
+  bytes sender = 10; // address
+  bytes recipient = 11; // address
+  string amount0 = 12; // int256
+  string amount1 = 13; // int256
+  string sqrt_price_x96 = 14; // uint160
+  string liquidity = 15; // uint128
+  int32 tick = 16; // int24
 }
 
 

--- a/proto/v1/uniswap-v4.proto
+++ b/proto/v1/uniswap-v4.proto
@@ -59,13 +59,15 @@ message Initialize {
 message Swap {
   // -- transaction --
   bytes tx_hash = 1;
+  bytes tx_from = 2; // tx.from
+  bytes tx_to = 3; // tx.to
 
   // -- call --
-  optional bytes caller = 2;
+  optional bytes caller = 4;
 
   // -- log --
-  bytes contract = 3; // log.address
-  uint64 ordinal = 4; // log.ordinal
+  bytes contract = 5; // log.address
+  uint64 ordinal = 6; // log.ordinal
 
   // -- event --
   bytes id = 10; // address (Pool ID)

--- a/uniswap-v2/src/lib.rs
+++ b/uniswap-v2/src/lib.rs
@@ -34,6 +34,8 @@ pub fn map_events(block: Block) -> Result<uniswap::Events, Error> {
                 events.swap.push(uniswap::Swap {
                     // -- transaction --
                     tx_hash: trx.hash.to_vec(),
+                    tx_from: trx.from.to_vec(),
+                    tx_to: trx.to.to_vec(),
                     // -- call --
                     caller,
                     // -- log --

--- a/uniswap-v2/substreams.yaml
+++ b/uniswap-v2/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: evm_uniswap_v2
-  version: v0.1.0
+  version: v0.1.1
   url: https://githubcom/pinax-network/substreams-evm-tokens
   description: Uniswap V2 for EVM
   image: ../image.png

--- a/uniswap-v3/src/lib.rs
+++ b/uniswap-v3/src/lib.rs
@@ -20,6 +20,8 @@ pub fn map_events(block: Block) -> Result<uniswap::Events, Error> {
                 events.swap.push(uniswap::Swap {
                     // -- transaction --
                     tx_hash: trx.hash.to_vec(),
+                    tx_from: trx.from.to_vec(),
+                    tx_to: trx.to.to_vec(),
                     // -- call --
                     caller,
                     // -- log --

--- a/uniswap-v3/substreams.yaml
+++ b/uniswap-v3/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: evm_uniswap_v3
-  version: v0.1.0
+  version: v0.1.1
   url: https://githubcom/pinax-network/substreams-evm-tokens
   description: Uniswap V3 for EVM
   image: ../image.png

--- a/uniswap-v4/src/lib.rs
+++ b/uniswap-v4/src/lib.rs
@@ -19,6 +19,8 @@ pub fn map_events(block: Block) -> Result<uniswap::Events, Error> {
                 events.swap.push(uniswap::Swap {
                     // -- transaction --
                     tx_hash: trx.hash.to_vec(),
+                    tx_from: trx.from.to_vec(),
+                    tx_to: trx.to.to_vec(),
                     // -- call --
                     caller,
                     // -- log --

--- a/uniswap-v4/substreams.yaml
+++ b/uniswap-v4/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: evm_uniswap_v4
-  version: v0.1.0
+  version: v0.1.1
   url: https://githubcom/pinax-network/substreams-evm-tokens
   description: Uniswap V4 for EVM
   image: ../image.png


### PR DESCRIPTION
Solves issue with Unique Wallets not being the correct amount

Add `tx_from` & `tx_to` to Uniswap V2/V3/V4 Substreams 

```proto
message Swap {
  // -- transaction --
  bytes tx_hash = 1;
  bytes tx_from = 2; // tx.from
  bytes tx_to = 3; // tx.to
```

## Example 

> `0xb1cc2cc9e223f28a4eeb7ad8517fc8c312ff6745`
> wallet which pushed transaction is only included in Transaction, not in the Uniswap V3 payload

https://etherscan.io/tx/0x6ea2d4679ea621d4a1422370244756628c7e404113658ea7cbe87d2e2d59b253

So the only way to fetch that wallet is to extract it from the transaction data

```json
{
  "txHash": "0x6ea2d4679ea621d4a1422370244756628c7e404113658ea7cbe87d2e2d59b253",
  "txFrom": "0xb1cc2cc9e223f28a4eeb7ad8517fc8c312ff6745",
  "txTo": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
  "caller": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
  "contract": "0x14154c15fc0fd3f91de557a1b6fdd2059972cd0b",
  "ordinal": "384",
  "sender": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
  "recipient": "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad",
  "amount0": "-16167536909092732115",
  "amount1": "40000000000000000000001",
  "sqrtPriceX96": "3927871433109551490001716034482",
  "liquidity": "231044405982556307729272",
  "tick": 78074
}
```

![image](https://github.com/user-attachments/assets/0547b7bb-7c06-40e1-87a3-779d5eb7f970)
