### PR TITLE
Add WETH9 transfers from Deposits & Withdrawals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "substreams-abis"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082566913c230bcb00b7c3d973583f8ae1e53fa9c02f365d29c8a6c72adca080"
+checksum = "75606b6ff1b150bd4e071f150b9b006cd6871855a7f79695e1d47bff3cf173d9"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -1314,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "substreams-database-change"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fe88d25f4c3d56fc2a92583708dc34822ea99fb3f96609f9d684f717974b27"
+checksum = "a64c606bd5c601991827163c766530ffbe620a4882178b4f22314fa6620b3746"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
@@ -1325,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "substreams-ethereum"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbebe786a62068f91593c89038fbe5ec70c9b784df716e450c52aa01b231f11"
+checksum = "c87eee2a37476f595b50fe4e247849ec21b9cb552682b9d9615aa7423b02a67d"
 dependencies = [
  "getrandom 0.2.16",
  "num-bigint",
@@ -1339,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "substreams-ethereum-abigen"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abdb13d5c4336d9d16ec31fbf8b4b41edde5f33b489186d7673a1017421b387"
+checksum = "c41e01b4ecd1ac87edddc8e3f68a46d7889674ff99648a5f91e8f75dfcc3fe7d"
 dependencies = [
  "anyhow",
  "ethabi 17.2.0",
@@ -1356,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "substreams-ethereum-core"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd3dbe2597daba8db0ae15b9a9cb4284236d0f39b4a5ba79c7c14978639613c"
+checksum = "bbb22830b2de14624f8b137b472221c684e553ad589a290bacfb08184598697c"
 dependencies = [
  "bigdecimal",
  "ethabi 17.2.0",
@@ -1372,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "substreams-ethereum-derive"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322330809d485b2926b65136b4b4eb1a9069c0a60275464f8a3c1f35a77f7c77"
+checksum = "65feb8d2a75671152da39bb85f0e1c4314f3ac3a95e0ac9f3c46be988eb11a5b"
 dependencies = [
  "ethabi 17.2.0",
  "heck 0.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,9 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 substreams = "0.6.1"
-substreams-abis = "0.4.2"
-substreams-ethereum = "0.10.4"
-substreams-database-change = "2.0"
+substreams-abis = "0.4.3"
+substreams-ethereum = "0.10.5"
+substreams-database-change = "2.1"
 prost = "0.13"
 prost-types = "0.13"
 

--- a/clickhouse-tokens/substreams.yaml
+++ b/clickhouse-tokens/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: evm_clickhouse_tokens
-  version: v1.14.0
+  version: v1.15.0
   url: https://github.com/pinax-network/substreams-evm-tokens
   description: ERC-20 & Native transfers & balances for EVM blockchains.
   image: ../image.png
@@ -16,11 +16,11 @@ imports:
   native_transfers: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.1.0/evm-native-transfers-v0.1.0.spkg
 
   # ERC-20
-  erc20_balances_rpc: https://github.com/pinax-network/substreams-evm-tokens/releases/download/erc20-balances-v0.1.1/evm-erc20-balances-rpc-v0.1.1.spkg
-  erc20_transfers: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.1.0/evm-erc20-transfers-v0.1.0.spkg
+  erc20_balances_rpc: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.2.0/evm-erc20-balances-rpc-v0.2.0.spkg
+  erc20_transfers: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.2.0/evm-erc20-transfers-v0.2.0.spkg
   erc20_metadata: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.1.1/evm-erc20-metadata-v0.1.1.spkg
   erc20_metadata_functions: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.1.0/evm-erc20-metadata-functions-v0.1.0.spkg
-  erc20_supply: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.1.1/evm-erc20-supply-v0.1.1.spkg
+  erc20_supply: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.2.0/evm-erc20-supply-v0.2.0.spkg
 
 binaries:
   default:

--- a/erc20-balances-rpc/substreams.yaml
+++ b/erc20-balances-rpc/substreams.yaml
@@ -1,13 +1,13 @@
 specVersion: v0.1.0
 package:
   name: evm_erc20_balances_rpc
-  version: v0.1.1
+  version: v0.2.0
   url: https://github.com/pinax-network/substreams-evm-tokens
   description: ERC20 balance changes via RPC
   image: ../image.png
 
 imports:
-  erc20_transfers: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.1.0/evm-erc20-transfers-v0.1.0.spkg
+  erc20_transfers: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.2.0/evm-erc20-transfers-v0.2.0.spkg
 
 protobuf:
   files:

--- a/erc20-supply/substreams.yaml
+++ b/erc20-supply/substreams.yaml
@@ -1,13 +1,13 @@
 specVersion: v0.1.0
 package:
   name: evm_erc20_supply
-  version: v0.1.1
+  version: v0.2.0
   url: https://github.com/pinax-network/substreams-evm-tokens
   description: ERC20 token supply
   image: ../image.png
 
 imports:
-  erc20_transfers: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.1.0/evm-erc20-transfers-v0.1.0.spkg
+  erc20_transfers: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.2.0/evm-erc20-transfers-v0.2.0.spkg
 
 protobuf:
   files:

--- a/erc20-transfers/Makefile
+++ b/erc20-transfers/Makefile
@@ -1,6 +1,5 @@
 ENDPOINT ?= eth.substreams.pinax.network:443
-ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-SINK_RANGE := ":"
+START_BLOCK ?= 20000000
 
 .PHONY: build
 build:
@@ -16,7 +15,7 @@ noop: build
 
 .PHONY: gui
 gui: build
-	substreams gui -e $(ENDPOINT) substreams.yaml map_events -s 5724000 -t 5725000
+	substreams gui -e $(ENDPOINT) substreams.yaml map_events -s $(START_BLOCK)
 
 .PHONY: prod
 prod: build

--- a/erc20-transfers/README.md
+++ b/erc20-transfers/README.md
@@ -2,4 +2,4 @@
 
 > Substreams for tracking ERC-20 transfers for EVM blockchains.
 
-Handles `Deposits` & `Withdrawls` from WETH9 as `Transfer` events.
+Handles `Deposits` & `Withdrawals` from WETH9 as `Transfer` events.

--- a/erc20-transfers/README.md
+++ b/erc20-transfers/README.md
@@ -1,3 +1,5 @@
 # EVM Tokens: `ERC20 Transfers`
 
 > Substreams for tracking ERC-20 transfers for EVM blockchains.
+
+Handles `Deposits` & `Withdrawls` from WETH9 as `Transfer` events.

--- a/erc20-transfers/src/lib.rs
+++ b/erc20-transfers/src/lib.rs
@@ -1,12 +1,17 @@
 use common::logs_with_caller;
 use proto::pb::evm::erc20::transfers::v1 as erc20;
+use substreams::log;
 use substreams_abis::evm::token::erc20::events;
+use substreams_abis::evm::tokens::weth::events as weth;
 use substreams_ethereum::pb::eth::v2::Block;
-use substreams_ethereum::Event;
+use substreams_ethereum::{Event, NULL_ADDRESS};
 
 #[substreams::handlers::map]
 fn map_events(block: Block) -> Result<erc20::Events, substreams::errors::Error> {
     let mut events = erc20::Events::default();
+    let mut weth_withdrawals = 0;
+    let mut weth_deposits = 0;
+    let mut erc20_transfers = 0;
 
     for trx in block.transactions() {
         for (log, caller) in logs_with_caller(&block, trx) {
@@ -28,8 +33,8 @@ fn map_events(block: Block) -> Result<erc20::Events, substreams::errors::Error> 
                     to: event.to.to_vec(),
                     value: event.value.to_string(),
                 });
+                erc20_transfers += 1;
             }
-
             // Approval event
             if let Some(event) = events::Approval::match_and_decode(log) {
                 events.approvals.push(erc20::Approval {
@@ -49,7 +54,55 @@ fn map_events(block: Block) -> Result<erc20::Events, substreams::errors::Error> 
                     value: event.value.to_string(),
                 });
             }
+
+            // WETH9 Deposit must trigger Transfer event
+            if let Some(event) = weth::Deposit::match_and_decode(log) {
+                events.transfers.push(erc20::Transfer {
+                    // -- transaction --
+                    tx_hash: trx.hash.to_vec(),
+
+                    // -- call --
+                    caller: caller.clone(),
+
+                    // -- log --
+                    contract: log.address.to_vec(),
+                    ordinal: log.ordinal,
+
+                    // -- event --
+                    from: NULL_ADDRESS.to_vec(),
+                    to: event.dst.to_vec(),
+                    value: event.wad.to_string(),
+                });
+                weth_deposits += 1;
+            }
+
+            // WETH9 Withdrawal must trigger Transfer event
+            if let Some(event) = weth::Withdrawal::match_and_decode(log) {
+                events.transfers.push(erc20::Transfer {
+                    // -- transaction --
+                    tx_hash: trx.hash.to_vec(),
+
+                    // -- call --
+                    caller: caller.clone(),
+
+                    // -- log --
+                    contract: log.address.to_vec(),
+                    ordinal: log.ordinal,
+
+                    // -- event --
+                    from: event.src.to_vec(),
+                    to: NULL_ADDRESS.to_vec(),
+                    value: event.wad.to_string(),
+                });
+                weth_withdrawals += 1;
+            }
         }
     }
+    log::info!(
+        "\nERC20 transfers={}\nWETH9 deposits={}\nWETH9 withdrawals={}",
+        erc20_transfers,
+        weth_deposits,
+        weth_withdrawals
+    );
     Ok(events)
 }

--- a/erc20-transfers/substreams.yaml
+++ b/erc20-transfers/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: evm_erc20_transfers
-  version: v0.1.0
+  version: v0.2.0
   url: https://github.com/pinax-network/substreams-evm-tokens
   description: ERC20 transfers
   image: ../image.png

--- a/uniswap-v2/Makefile
+++ b/uniswap-v2/Makefile
@@ -1,7 +1,5 @@
 ENDPOINT ?= eth.substreams.pinax.network:443
-ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-SINK_RANGE := ":"
-START_BLOCK := 12205119
+START_BLOCK ?= 12205119
 
 .PHONY: build
 build:


### PR DESCRIPTION
Fixes https://github.com/pinax-network/substreams-evm-tokens/issues/84

WETH (version 9) only includes `Deposit` & `Withdraw` events, does not include a `Transfer` event

This can cause the user to:
- Redeem WETH via `withdraw`
- ✅ Update Native Balances
- ❌ NOT update ERC-20 balance (remains the same)