### PR TITLE
fix: handle mismatched ids and values lengths in ERC1155 batch transfers

### DIFF
--- a/clickhouse-nfts/src/erc1155.rs
+++ b/clickhouse-nfts/src/erc1155.rs
@@ -31,11 +31,12 @@ pub fn process_erc1155(tables: &mut substreams_database_change::tables::Tables, 
     for event in events.transfers_batch {
         if event.ids.len() != event.values.len() {
             substreams::log::info!(
-                "Mismatch between ids length ({}) and values length ({}) in ERC1155 batch transfer in trx {}",
+                "Invalid ERC1155 TransferBatch event: mismatch between ids length ({}) and values length ({}) in trx {}",
                 event.ids.len(),
                 event.values.len(),
                 bytes_to_hex(&event.tx_hash)
             );
+            continue;
         }
 
         event.ids.iter().zip(event.values.iter()).for_each(|(id, value)| {

--- a/clickhouse-uniswaps/schema.sql
+++ b/clickhouse-uniswaps/schema.sql
@@ -983,6 +983,7 @@ CREATE TABLE IF NOT EXISTS uniswap_v4_protocol_fee_updated (
 ENGINE = ReplacingMergeTree
 ORDER BY (timestamp, block_num, `index`);
 
+
 -- latest ERC-20 Metadata --
 CREATE TABLE IF NOT EXISTS erc20_metadata  (
    -- block --


### PR DESCRIPTION
Fixes #89 