### PR TITLE
Fix incorrect `amount` in transfers

### DIFF
--- a/clickhouse-tokens/Makefile
+++ b/clickhouse-tokens/Makefile
@@ -24,7 +24,7 @@ prod: build
 
 .PHONY: dev
 dev: build
-	substreams-sink-sql run clickhouse://default:default@localhost:9000/default substreams.yaml -e $(ENDPOINT) 0: --final-blocks-only --undo-buffer-size 1 --on-module-hash-mistmatch=warn --batch-block-flush-interval 1 --infinite-retry --development-mode
+	substreams-sink-sql run clickhouse://default:default@localhost:9000/default substreams.yaml -e $(ENDPOINT) 22586773:22587773 --final-blocks-only --undo-buffer-size 1 --on-module-hash-mistmatch=warn --batch-block-flush-interval 1 --infinite-retry
 
 .PHONY: setup
 setup: pack

--- a/clickhouse-tokens/schema.3.view.transfers.sql
+++ b/clickhouse-tokens/schema.3.view.transfers.sql
@@ -66,8 +66,8 @@ SELECT
     -- event --
     `from`,
     `to`,
-    value AS amount,
-    value / pow(10, decimals) AS value,
+    t.value AS amount,
+    t.value / pow(10, decimals) AS value,
 
     -- ERC20 metadata --
     decimals,
@@ -103,11 +103,11 @@ SELECT
     -- event --
     `from`,
     `to`,
-    value AS amount,
-    value / pow(10, decimals) AS value,
+    t.value AS amount,
+    t.value / pow(10, decimals) AS value,
 
     -- ERC20 metadata --
     decimals,
     symbol,
     name
-FROM native_transfers;
+FROM native_transfers AS t;

--- a/clickhouse-tokens/schema.sql
+++ b/clickhouse-tokens/schema.sql
@@ -545,8 +545,8 @@ SELECT
     -- event --
     `from`,
     `to`,
-    value AS amount,
-    value / pow(10, decimals) AS value,
+    t.value AS amount,
+    t.value / pow(10, decimals) AS value,
 
     -- ERC20 metadata --
     decimals,
@@ -582,14 +582,14 @@ SELECT
     -- event --
     `from`,
     `to`,
-    value AS amount,
-    value / pow(10, decimals) AS value,
+    t.value AS amount,
+    t.value / pow(10, decimals) AS value,
 
     -- ERC20 metadata --
     decimals,
     symbol,
     name
-FROM native_transfers;
+FROM native_transfers AS t;
 
 
 CREATE TABLE IF NOT EXISTS cursors

--- a/clickhouse-tokens/substreams.yaml
+++ b/clickhouse-tokens/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: evm_clickhouse_tokens
-  version: v1.15.0
+  version: v1.15.1
   url: https://github.com/pinax-network/substreams-evm-tokens
   description: ERC-20 & Native transfers & balances for EVM blockchains.
   image: ../image.png


### PR DESCRIPTION
Fixes: https://github.com/pinax-network/substreams-evm-tokens/issues/92

> Default of ClickHouse is to resolve names from aliases first and then column names:

https://clickhouse.com/docs/operations/settings/settings#prefer_column_name_to_alias

![image](https://github.com/user-attachments/assets/d87ced07-ccf1-4cd0-b334-8729a912fcd5)
