### PR TITLE
Remove duplicate eth_call 

### DIFF
--- a/erc20-metadata/substreams.yaml
+++ b/erc20-metadata/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: evm_erc20_metadata
-  version: v0.1.1
+  version: v0.1.2
   url: https://github.com/pinax-network/substreams-evm-tokens
   description: ERC20 Token Metadata via RPC
   image: ../image.png


### PR DESCRIPTION
`sai::functions::Name` and `erc20::functions::Name` have the same call signature (but different outputs) and that creates duplicate eth_calls in one batch.

Duplicate eth_calls seem to cause issues with some nodes and/or caching proxies.

We really just need to send one `erc20::functions::Name` eth_call and then try to decode results with 2 different function types instead