### PR TITLE
Add `eth_get_balance` support for Native Balances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "substreams-abis"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75606b6ff1b150bd4e071f150b9b006cd6871855a7f79695e1d47bff3cf173d9"
+checksum = "8f54dd12a1e728f5cc09ac3983656ef7e4e9aa32f04aed8447b1cf2d9a99303c"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "substreams-database-change"
-version = "2.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c606bd5c601991827163c766530ffbe620a4882178b4f22314fa6620b3746"
+checksum = "a93bcd1a0cda40746b8c3a3d64b0945986722b2ca3b686595cfbb3f295246d7d"
 dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
@@ -1314,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "substreams-ethereum"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87eee2a37476f595b50fe4e247849ec21b9cb552682b9d9615aa7423b02a67d"
+checksum = "a2fc683b368e317c60064267dbddc5d8ce290ef00170eb74df8cdde7cda939f3"
 dependencies = [
  "getrandom 0.2.16",
  "num-bigint",
@@ -1328,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "substreams-ethereum-abigen"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e01b4ecd1ac87edddc8e3f68a46d7889674ff99648a5f91e8f75dfcc3fe7d"
+checksum = "72db7f7ca7766cb393c8479add840c76139bb25818f38d6db80c2be3b49b02a2"
 dependencies = [
  "anyhow",
  "ethabi 17.2.0",
@@ -1345,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "substreams-ethereum-core"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb22830b2de14624f8b137b472221c684e553ad589a290bacfb08184598697c"
+checksum = "533e22206a9709568ed829037ed49838d4c8c441b799f9c43a20c5a7d84027c9"
 dependencies = [
  "bigdecimal",
  "ethabi 17.2.0",
@@ -1361,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "substreams-ethereum-derive"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65feb8d2a75671152da39bb85f0e1c4314f3ac3a95e0ac9f3c46be988eb11a5b"
+checksum = "b66155cfe7197efafcd46135fb8da7bfa344142c20a9c25d8fdb97cd1995cf8c"
 dependencies = [
  "ethabi 17.2.0",
  "heck 0.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 substreams = "0.6.1"
-substreams-abis = "0.4.3"
-substreams-ethereum = "0.10.5"
-substreams-database-change = "2.1"
+substreams-abis = "0.4.5"
+substreams-ethereum = "0.10.6"
+substreams-database-change = "2.1.2"
 prost = "0.13"
 prost-types = "0.13"
 

--- a/native-balances/Makefile
+++ b/native-balances/Makefile
@@ -1,6 +1,7 @@
-ENDPOINT ?= eth.substreams.pinax.network:443
-ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-SINK_RANGE := ":"
+ENDPOINT ?= avalanche.substreams.pinax.network:443
+START_BLOCK ?= 10000000
+STOP_BLOCK ?= 10001000
+PARALLEL_JOBS ?= 500
 
 .PHONY: build
 build:
@@ -12,8 +13,12 @@ pack: build
 
 .PHONY: noop
 noop: build
-	substreams-sink-noop $(ENDPOINT) substreams.yaml map_events -H "X-Sf-Substreams-Parallel-Jobs: 3000"
+	substreams-sink-noop $(ENDPOINT) substreams.yaml map_events -H "X-Sf-Substreams-Parallel-Jobs: $(PARALLEL_JOBS)" $(START_BLOCK):
 
 .PHONY: gui
 gui: build
-	substreams gui -e $(ENDPOINT) substreams.yaml map_events -s 10000000 --limit-processed-blocks 0
+	substreams gui -e $(ENDPOINT) substreams.yaml map_events -s $(START_BLOCK) -s $(STOP_BLOCK) --network mainnet
+
+.PHONY: prod
+prod: build
+	substreams gui -e $(ENDPOINT) substreams.yaml map_events -s $(START_BLOCK) -s $(STOP_BLOCK) -t 0 --limit-processed-blocks 0 --production-mode  -H "X-Sf-Substreams-Parallel-Jobs: $(PARALLEL_JOBS)"

--- a/native-balances/Makefile
+++ b/native-balances/Makefile
@@ -1,4 +1,5 @@
 ENDPOINT ?= avalanche.substreams.pinax.network:443
+# ENDPOINT ?= avalanche-mainnet.streamingfast.io:443
 START_BLOCK ?= 10000000
 STOP_BLOCK ?= 10001000
 PARALLEL_JOBS ?= 500

--- a/native-balances/src/calls.rs
+++ b/native-balances/src/calls.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+
+use common::Address;
+use substreams::{log, scalar::BigInt, Hex};
+use substreams_ethereum::rpc::eth_get_balance;
+use substreams_ethereum::rpc::RpcBatch;
+
+// Returns the token URI.
+pub fn batch_balance_of<'a>(contract_owners: &'a [(&Address, &Address)], chunk_size: usize) -> HashMap<(&'a Address, &'a Address), BigInt> {
+    let mut results: HashMap<(&Address, &Address), BigInt> = HashMap::with_capacity(contract_owners.len());
+
+    for chunk in contract_owners.chunks(chunk_size) {
+        let batch = chunk.iter().fold(RpcBatch::new(), |batch, (contract, owner)| {
+            batch.add(erc20::functions::BalanceOf { account: owner.to_vec() }, contract.to_vec())
+        });
+        let responses = batch.execute().expect("failed to execute erc20::functions::BalanceOf batch").responses;
+        for (i, (contract, owner)) in chunk.iter().enumerate() {
+            if let Some(value) = RpcBatch::decode::<BigInt, erc20::functions::BalanceOf>(&responses[i]) {
+                results.insert((contract, owner), value);
+            } else {
+                substreams::log::info!(
+                    "Failed to decode erc20::BalanceOf for contract={:?} owner={:?}",
+                    Hex::encode(contract),
+                    Hex::encode(owner)
+                );
+            }
+        }
+    }
+    log::info!(
+        "\nBalances={}\nRpcBatch={}\nMissing={}",
+        contract_owners.len(),
+        contract_owners.chunks(chunk_size).len(),
+        contract_owners.len() - results.len()
+    );
+    results
+}

--- a/native-balances/src/calls.rs
+++ b/native-balances/src/calls.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 
 use common::Address;
-use substreams::{pb::substreams::Clock, scalar::BigInt};
+use substreams::scalar::BigInt;
 use substreams_ethereum::{
     pb::eth::rpc::{RpcGetBalanceRequest, RpcGetBalanceRequests},
     rpc::eth_get_balance,
 };
 
 // Returns the token URI.
-pub fn batch_balance_of<'a>(clock: &Clock, owners: &'a [&Address], chunk_size: usize) -> HashMap<&'a Address, BigInt> {
+pub fn batch_eth_balance_of<'a>(block: u64, owners: &'a [&Address], _chunk_size: usize) -> HashMap<&'a Address, BigInt> {
     let mut results: HashMap<&Address, BigInt> = HashMap::with_capacity(owners.len());
 
     let mut requests = RpcGetBalanceRequests {
@@ -17,12 +17,16 @@ pub fn batch_balance_of<'a>(clock: &Clock, owners: &'a [&Address], chunk_size: u
     for owner in owners {
         requests.requests.push(RpcGetBalanceRequest {
             address: owner.to_vec(),
-            block: clock.number.to_string(),
+            block: block.to_string(),
         });
     }
     let balances = eth_get_balance(&requests);
     for (i, owner) in owners.iter().enumerate() {
-        results.insert(owner, balances[i]);
+        let response = &balances.responses[i];
+        if response.failed {
+            continue;
+        }
+        results.insert(owner, BigInt::from_unsigned_bytes_be(&response.balance));
     }
     results
 }

--- a/native-balances/src/lib.rs
+++ b/native-balances/src/lib.rs
@@ -80,21 +80,19 @@ pub fn map_events(params: String, block: Block) -> Result<Events, Error> {
     // - call.caller
     // - call.address_delegates_to
     let mut accounts = HashSet::new();
-    if block.detail_level != 0 {
-        for trx in &block.transaction_traces {
-            accounts.insert(trx.from.to_vec());
-            accounts.insert(trx.to.to_vec());
+    for trx in &block.transaction_traces {
+        accounts.insert(trx.from.to_vec());
+        accounts.insert(trx.to.to_vec());
 
-            for call_view in trx.calls() {
-                let call = call_view.call;
-                accounts.insert(call.address.to_vec());
-                accounts.insert(call.caller.to_vec());
-                if let Some(address_delegates_to) = &call.address_delegates_to {
-                    accounts.insert(address_delegates_to.to_vec());
-                }
-                for log in call.logs.iter() {
-                    accounts.insert(log.address.to_vec());
-                }
+        for call_view in trx.calls() {
+            let call = call_view.call;
+            accounts.insert(call.address.to_vec());
+            accounts.insert(call.caller.to_vec());
+            if let Some(address_delegates_to) = &call.address_delegates_to {
+                accounts.insert(address_delegates_to.to_vec());
+            }
+            for log in call.logs.iter() {
+                accounts.insert(log.address.to_vec());
             }
         }
     }

--- a/native-balances/substreams.yaml
+++ b/native-balances/substreams.yaml
@@ -21,6 +21,7 @@ modules:
   - name: map_events
     kind: map
     inputs:
+      - params: string
       - source: sf.ethereum.type.v2.Block
     output:
       type: proto:evm.native.balances.v1.Events

--- a/native-balances/substreams.yaml
+++ b/native-balances/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: evm_native_balances
-  version: v0.1.0
+  version: v0.2.0
   url: https://github.com/pinax-network/substreams-evm-tokens
   description: Extracts Native balances for EVM blockchains.
   image: ../image.png

--- a/native-balances/substreams.yaml
+++ b/native-balances/substreams.yaml
@@ -26,3 +26,6 @@ modules:
       type: proto:evm.native.balances.v1.Events
 
 network: mainnet
+
+params:
+  map_events: 25 # CHUNK_SIZE (Batch RPC Calls)


### PR DESCRIPTION
Test with Avalanche network (no extended blocks)
- [x] Now supports `eth_get_balance` to fetch Native balances for extended & no-extended blocks
- [ ] ❌  missing `chunk_size`