### PR TITLE
Ordering of Native Balance changes

### DIFF
--- a/clickhouse-tokens/Makefile
+++ b/clickhouse-tokens/Makefile
@@ -1,6 +1,6 @@
 ENDPOINT ?= eth.substreams.pinax.network:443
-START_BLOCK ?= 23142793
-STOP_BLOCK ?= 23142794
+START_BLOCK ?= 6803275
+STOP_BLOCK ?= 6803276
 PARALLEL_JOBS ?= 500
 
 .PHONY: build
@@ -17,7 +17,11 @@ noop: build
 
 .PHONY: gui
 gui: build
-	substreams gui -e $(ENDPOINT) substreams.yaml db_out -s $(START_BLOCK) --network eth
+	substreams gui -e $(ENDPOINT) substreams.yaml db_out -s $(START_BLOCK) -t $(STOP_BLOCK)
+
+.PHONY: run
+run: build
+	substreams run -e $(ENDPOINT) substreams.yaml db_out -s $(START_BLOCK) -t $(STOP_BLOCK) --production-mode
 
 .PHONY: prod
 prod: build

--- a/clickhouse-tokens/substreams.yaml
+++ b/clickhouse-tokens/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: evm_clickhouse_tokens
-  version: v1.17.0
+  version: v1.17.1
   url: https://github.com/pinax-network/substreams-evm-tokens
   description: ERC-20 & Native transfers & balances for EVM blockchains.
   image: ../image.png
@@ -12,14 +12,14 @@ imports:
   sql: https://github.com/streamingfast/substreams-sink-sql/releases/download/protodefs-v1.0.7/substreams-sink-sql-protodefs-v1.0.7.spkg
 
   # Native
-  native_balances: https://github.com/pinax-network/substreams-evm-tokens/releases/download/native-balances-v0.2.0/evm-native-balances-v0.2.0.spkg
+  native_balances: https://github.com/pinax-network/substreams-evm-tokens/releases/download/clickhouse-tokens-v1.17.1/evm-native-balances-v0.2.1.spkg
   native_transfers: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.1.0/evm-native-transfers-v0.1.0.spkg
 
   # ERC-20
-  erc20_balances_rpc: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.2.0/evm-erc20-balances-rpc-v0.2.1.spkg
+  erc20_balances_rpc: https://github.com/pinax-network/substreams-evm-tokens/releases/download/clickhouse-tokens-v1.17.1/evm-erc20-balances-rpc-v0.2.1.spkg
   erc20_transfers: https://github.com/pinax-network/substreams-evm-tokens/releases/download/erc20-transfers-v0.2.1/evm-erc20-transfers-v0.2.1.spkg
-  erc20_metadata: https://github.com/pinax-network/substreams-evm-tokens/releases/download/erc20-metadata-v0.2.1/evm-erc20-metadata-v0.2.1.spkg
-  erc20_supply: https://github.com/pinax-network/substreams-evm-tokens/releases/download/tokens-v0.2.0/evm-erc20-supply-v0.2.0.spkg
+  erc20_metadata: https://github.com/pinax-network/substreams-evm-tokens/releases/download/clickhouse-tokens-v1.17.1/evm-erc20-metadata-v0.2.2.spkg
+  erc20_supply: https://github.com/pinax-network/substreams-evm-tokens/releases/download/clickhouse-tokens-v1.17.1/evm-erc20-supply-v0.2.1.spkg
 
 binaries:
   default:

--- a/native-balances/Makefile
+++ b/native-balances/Makefile
@@ -1,6 +1,7 @@
-ENDPOINT ?= avalanche.substreams.pinax.network:443
+ENDPOINT ?= eth.substreams.pinax.network:443
 # ENDPOINT ?= avalanche-mainnet.streamingfast.io:443
-START_BLOCK ?= 4500000
+START_BLOCK ?= 6803275
+STOP_BLOCK ?= 6803276
 PARALLEL_JOBS ?= 500
 
 .PHONY: build
@@ -15,9 +16,13 @@ pack: build
 noop: build
 	substreams-sink-noop $(ENDPOINT) substreams.yaml map_events -H "X-Sf-Substreams-Parallel-Jobs: $(PARALLEL_JOBS)" $(START_BLOCK):
 
+.PHONY: run
+run: build
+	substreams run -e $(ENDPOINT) substreams.yaml map_events -s $(START_BLOCK) -t $(STOP_BLOCK) --network mainnet
+
 .PHONY: gui
 gui: build
-	substreams gui -e $(ENDPOINT) substreams.yaml map_events -s $(START_BLOCK) --network mainnet
+	substreams gui -e $(ENDPOINT) substreams.yaml map_events -s $(START_BLOCK) -t $(STOP_BLOCK) --network mainnet
 
 .PHONY: prod
 prod: build


### PR DESCRIPTION
NOTE: The order of processing events is crucial to maintain accurate balance states.
Ethereum balance changes occur in several phases within a block and transaction:

Ref issue: https://github.com/pinax-network/substreams-evm-tokens/issues/126

1. Block Rewards → miner/validator credited first.
2. Tx Gas Prepayment → sender debited upfront.
3. Execution Phase → calls, transfers, system calls update balances.
4. Gas Refund + Miner Reward → settlement at the end of the transaction.
5. RPC eth_getBalance → only observes the final post-state snapshot.