### PR TITLE
Fix/clickhouse tokens v1.18.0

### DIFF
--- a/clickhouse-tokens/schema.0.template.sql
+++ b/clickhouse-tokens/schema.0.template.sql
@@ -44,6 +44,34 @@ CREATE TABLE IF NOT EXISTS TEMPLATE_LOGS (
 ENGINE = ReplacingMergeTree
 PARTITION BY toYYYYMM(timestamp)
 ORDER BY (
-    timestamp, block_num, block_hash, tx_hash, log_index
+    timestamp, block_num, block_hash, log_index
+)
+COMMENT 'TEMPLATE for event logs';
+
+CREATE TABLE IF NOT EXISTS TEMPLATE_TRANSACTIONS (
+    -- block --
+    block_num            UInt32,
+    block_hash           String,
+    timestamp            DateTime(0, 'UTC'),
+
+    -- transaction --
+    tx_hash              String COMMENT 'transaction hash',
+
+    -- ordering --
+    transaction_index           UInt32 COMMENT 'transaction index in the block',
+    instruction_index           UInt32 COMMENT 'instruction index in the transaction',
+
+    -- indexes --
+    INDEX idx_block_num          (block_num)          TYPE minmax               GRANULARITY 1,
+    INDEX idx_block_hash         (block_hash)         TYPE bloom_filter(0.005)  GRANULARITY 1,
+    INDEX idx_timestamp          (timestamp)          TYPE minmax               GRANULARITY 1,
+    INDEX idx_tx_hash            (tx_hash)            TYPE bloom_filter(0.005)  GRANULARITY 1,
+    INDEX idx_transaction_index  (transaction_index)  TYPE minmax               GRANULARITY 1,
+    INDEX idx_instruction_index  (instruction_index)  TYPE minmax               GRANULARITY 1
+)
+ENGINE = ReplacingMergeTree
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (
+    timestamp, block_num, block_hash, tx_hash, transaction_index
 )
 COMMENT 'TEMPLATE for event logs';

--- a/clickhouse-tokens/src/erc20_balances.rs
+++ b/clickhouse-tokens/src/erc20_balances.rs
@@ -4,18 +4,13 @@ use substreams::pb::substreams::Clock;
 
 use common::clickhouse::set_clock;
 
-pub fn process_erc20_balances(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, events: erc20::balances::v1::Events, index: &mut u32) {
+pub fn process_erc20_balances(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, events: erc20::balances::v1::Events) {
     for event in events.balances_by_account {
-        process_erc20_balance_by_account(tables, clock, event, index);
+        process_erc20_balance_by_account(tables, clock, event);
     }
 }
 
-fn process_erc20_balance_by_account(
-    tables: &mut substreams_database_change::tables::Tables,
-    clock: &Clock,
-    event: erc20::balances::v1::BalanceByAccount,
-    index: &mut u32,
-) {
+fn process_erc20_balance_by_account(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, event: erc20::balances::v1::BalanceByAccount) {
     let address = bytes_to_hex(&event.account);
     let contract = bytes_to_hex(&event.contract);
     let row = tables
@@ -26,5 +21,4 @@ fn process_erc20_balance_by_account(
         .set("balance", event.amount);
 
     set_clock(clock, row);
-    *index += 1;
 }

--- a/clickhouse-tokens/src/erc20_metadata.rs
+++ b/clickhouse-tokens/src/erc20_metadata.rs
@@ -2,12 +2,12 @@ use common::{bytes_to_hex, clickhouse::set_clock};
 use proto::pb::evm::erc20;
 use substreams::pb::substreams::Clock;
 
-pub fn process_erc20_metadata(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, events: erc20::metadata::v1::Events, index: &mut u32) {
+pub fn process_erc20_metadata(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, events: erc20::metadata::v1::Events) {
     for event in events.metadata_initialize {
-        process_erc20_metadata_initialize(tables, &clock, event, index);
+        process_erc20_metadata_initialize(tables, &clock, event);
     }
     for event in events.metadata_changes {
-        process_erc20_metadata_changes(tables, &clock, event, index);
+        process_erc20_metadata_changes(tables, &clock, event);
     }
 }
 
@@ -15,7 +15,6 @@ pub fn process_erc20_metadata_initialize(
     tables: &mut substreams_database_change::tables::Tables,
     clock: &Clock,
     event: erc20::metadata::v1::MetadataInitialize,
-    index: &mut u32,
 ) {
     let address = bytes_to_hex(&event.address);
     let row = tables
@@ -26,15 +25,9 @@ pub fn process_erc20_metadata_initialize(
         .set("symbol", event.symbol.unwrap_or_default());
 
     set_clock(clock, row);
-    *index += 1;
 }
 
-pub fn process_erc20_metadata_changes(
-    tables: &mut substreams_database_change::tables::Tables,
-    clock: &Clock,
-    event: erc20::metadata::v1::MetadataChanges,
-    index: &mut u32,
-) {
+pub fn process_erc20_metadata_changes(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, event: erc20::metadata::v1::MetadataChanges) {
     let address = bytes_to_hex(&event.address);
     let row = tables
         .create_row("metadata_changes", [("contract", address.to_string())])
@@ -43,5 +36,4 @@ pub fn process_erc20_metadata_changes(
         .set("symbol", event.symbol.unwrap_or_default());
 
     set_clock(clock, row);
-    *index += 1;
 }

--- a/clickhouse-tokens/src/erc20_supply.rs
+++ b/clickhouse-tokens/src/erc20_supply.rs
@@ -4,9 +4,9 @@ use substreams::pb::substreams::Clock;
 
 use common::clickhouse::set_clock;
 
-pub fn process_erc20_supply(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, events: erc20::supply::v1::Events, index: &mut u32) {
+pub fn process_erc20_supply(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, events: erc20::supply::v1::Events) {
     for event in events.total_supply_by_contracts {
-        process_erc20_total_supply_by_contracts(tables, clock, event, index);
+        process_erc20_total_supply_by_contracts(tables, clock, event);
     }
 }
 
@@ -14,7 +14,6 @@ fn process_erc20_total_supply_by_contracts(
     tables: &mut substreams_database_change::tables::Tables,
     clock: &Clock,
     event: erc20::supply::v1::TotalSupplyByContract,
-    index: &mut u32,
 ) {
     let contract = bytes_to_hex(&event.contract);
     let row = tables
@@ -24,5 +23,4 @@ fn process_erc20_total_supply_by_contracts(
         .set("total_supply", event.total_supply);
 
     set_clock(clock, row);
-    *index += 1;
 }

--- a/clickhouse-tokens/src/erc20_transfers.rs
+++ b/clickhouse-tokens/src/erc20_transfers.rs
@@ -5,37 +5,35 @@ use common::{
 use proto::pb::evm::erc20;
 use substreams::pb::substreams::Clock;
 
-pub fn process_erc20_transfers(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, events: erc20::transfers::v1::Events, index: &mut u32) {
+pub fn process_erc20_transfers(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, events: erc20::transfers::v1::Events) {
     // TO-DO: ⚠️ add transaction index / instruction index to have a proper ordering
     for event in events.transfers {
-        process_erc20_transfer(tables, clock, event, index);
+        process_erc20_transfer(tables, clock, event);
     }
 
     for event in events.approvals {
-        process_erc20_approval(tables, clock, event, index);
+        process_erc20_approval(tables, clock, event);
     }
 }
 
-fn process_erc20_transfer(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, event: erc20::transfers::v1::Transfer, index: &mut u32) {
+fn process_erc20_transfer(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, event: erc20::transfers::v1::Transfer) {
     let row = tables
-        .create_row("transfers", log_key(clock, *index))
+        .create_row("transfers", log_key(clock, event.log_index))
         // -- event --
         .set("from", bytes_to_hex(&event.from))
         .set("to", bytes_to_hex(&event.to))
         .set("value", event.value.to_string());
 
     set_log_v2(clock, event.tx_hash, event.contract, event.caller, row);
-    *index += 1;
 }
 
-fn process_erc20_approval(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, event: erc20::transfers::v1::Approval, index: &mut u32) {
+fn process_erc20_approval(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, event: erc20::transfers::v1::Approval) {
     let row = tables
-        .create_row("approvals", log_key(clock, *index))
+        .create_row("approvals", log_key(clock, event.log_index))
         // -- event --
         .set("owner", bytes_to_hex(&event.owner))
         .set("spender", bytes_to_hex(&event.spender))
         .set("value", event.value.to_string());
 
     set_log_v2(clock, event.tx_hash, event.contract, event.caller, row);
-    *index += 1;
 }

--- a/clickhouse-tokens/src/lib.rs
+++ b/clickhouse-tokens/src/lib.rs
@@ -25,25 +25,24 @@ pub fn db_out(
 ) -> Result<DatabaseChanges, Error> {
     let mut tables = substreams_database_change::tables::Tables::new();
     clock = update_genesis_clock(clock);
-    let mut index = 0;
 
     // -- ERC20 Metadata --
-    erc20_metadata::process_erc20_metadata(&mut tables, &clock, erc20_metadata, &mut index);
+    erc20_metadata::process_erc20_metadata(&mut tables, &clock, erc20_metadata);
 
     // -- ERC20 Balances --
-    erc20_balances::process_erc20_balances(&mut tables, &clock, erc20_balances_rpc, &mut index);
+    erc20_balances::process_erc20_balances(&mut tables, &clock, erc20_balances_rpc);
 
     // -- ERC20 Transfers --
-    erc20_transfers::process_erc20_transfers(&mut tables, &clock, erc20_transfers, &mut index);
+    erc20_transfers::process_erc20_transfers(&mut tables, &clock, erc20_transfers);
 
     // -- ERC20 Total Supply --
-    erc20_supply::process_erc20_supply(&mut tables, &clock, erc20_supply, &mut index);
+    erc20_supply::process_erc20_supply(&mut tables, &clock, erc20_supply);
 
     // -- Native Balances --
-    native_balances::process_native_balances(&mut tables, &clock, native_balances, &mut index);
+    native_balances::process_native_balances(&mut tables, &clock, native_balances);
 
     // -- Native Transfers --
-    native_transfers::process_native_transfers(&mut tables, &clock, native_transfers, &mut index);
+    native_transfers::process_native_transfers(&mut tables, &clock, native_transfers);
 
     Ok(tables.to_database_changes())
 }

--- a/clickhouse-tokens/src/native_balances.rs
+++ b/clickhouse-tokens/src/native_balances.rs
@@ -3,10 +3,9 @@ use proto::pb::evm::native;
 use substreams::pb::substreams::Clock;
 
 use common::clickhouse::set_clock;
-use common::NATIVE_ADDRESS;
 
 // ❗ ERROR in ordering is missing transaction index / instruction index
-pub fn process_native_balances(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, events: native::balances::v1::Events, index: &mut u32) {
+pub fn process_native_balances(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, events: native::balances::v1::Events) {
     // NOTE: The order of processing events is crucial to maintain accurate balance states.
     // Ethereum balance changes occur in several phases within a block and transaction:
     //
@@ -18,36 +17,29 @@ pub fn process_native_balances(tables: &mut substreams_database_change::tables::
     // 4. Gas Refund + Miner Reward → settlement at the end of the transaction.
     // 5. RPC eth_getBalance → only observes the final post-state snapshot.
     for event in events.extended_balances_by_account_from_block_rewards {
-        process_native_balance_by_account(tables, clock, event, index);
+        process_native_balance_by_account(tables, clock, event);
     }
     for event in events.extended_balances_by_account_from_gas {
-        process_native_balance_by_account(tables, clock, event, index);
+        process_native_balance_by_account(tables, clock, event);
     }
     for event in events.extended_balances_by_account_from_system_calls {
-        process_native_balance_by_account(tables, clock, event, index);
+        process_native_balance_by_account(tables, clock, event);
     }
     for event in events.extended_balances_by_account_from_calls {
-        process_native_balance_by_account(tables, clock, event, index);
+        process_native_balance_by_account(tables, clock, event);
     }
     for event in events.balances_by_account {
-        process_native_balance_by_account(tables, clock, event, index);
+        process_native_balance_by_account(tables, clock, event);
     }
 }
 
-fn process_native_balance_by_account(
-    tables: &mut substreams_database_change::tables::Tables,
-    clock: &Clock,
-    event: native::balances::v1::BalanceByAccount,
-    index: &mut u32,
-) {
+fn process_native_balance_by_account(tables: &mut substreams_database_change::tables::Tables, clock: &Clock, event: native::balances::v1::BalanceByAccount) {
     let address = bytes_to_hex(&event.account);
     let row = tables
-        .create_row("balances", [("address", address.clone()), ("contract", NATIVE_ADDRESS.to_string())])
+        .create_row("balances", [("address", address.clone())])
         // -- event --
-        .set("contract", NATIVE_ADDRESS)
         .set("address", address)
         .set("balance", event.amount);
 
     set_clock(clock, row);
-    *index += 1;
 }

--- a/common/src/clickhouse.rs
+++ b/common/src/clickhouse.rs
@@ -22,6 +22,16 @@ pub fn log_key(clock: &Clock, log_index: u32) -> [(&'static str, String); 4] {
     ]
 }
 
+pub fn transaction_key(clock: &Clock, tx_index: u32) -> [(&'static str, String); 4] {
+    let seconds = clock.timestamp.as_ref().expect("clock.timestamp is required").seconds;
+    [
+        ("timestamp", seconds.to_string()),
+        ("block_num", clock.number.to_string()),
+        ("block_hash", format!("0x{}", &clock.id)),
+        ("tx_index", tx_index.to_string()),
+    ]
+}
+
 // Helper function to set clock data in a row
 pub fn set_clock(clock: &Clock, row: &mut Row) {
     row.set("block_num", clock.number.to_string())


### PR DESCRIPTION
- drop `metadata` TABLE (was causing additional compute on inserts), only allow `metadata_view` (compute now moved at query time)